### PR TITLE
[BUG] : Fix alignment part 2

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -34,7 +34,7 @@
     <img src="https://github.com/Libra-foundation/.github/blob/main/profile/resources/ReactTemplate.svg" alt="ReactTemplate" height="50"/>
     <details>
         <summary><h3>React template</h3></summary>
-        <div align="center">
+        <div align="left">
             <p>React template is a free, reliable and easy to maintain template for react project. Based on `react-scripts`, we configured a set of utility packages that automates most of the annoying work. To help everyone avoid common mistakes and keep the code nice and tidy, we added hardened rules.  This template is particularly useful for newcomers to guide them through the learning of React Typescript with good practices.</p>
         </div>
     </details>


### PR DESCRIPTION
## 1) Description

Only one little change was performed on a `div` tag. Property `align` with value `center` on text of Collaboratio description was changed by `left`.

## 2) Technical choice

Because GitHub only accepts depreciated alignment method. The non-depreciated method is to use the style property with a text align value equal to center.

**Depreciated method :**
```HTML
<div align="center"></div>
```

**New method but not available :**
```HTML
<div style="text-align: center;"></div>
```

## 3) Checks

- [x] My code follows the contributing guidelines
- [x] I have read the code of conduct
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes